### PR TITLE
Prevent issues with implicit datetime conversion

### DIFF
--- a/src/LightNap.Core/Extensions/ApplicationUserExtensions.cs
+++ b/src/LightNap.Core/Extensions/ApplicationUserExtensions.cs
@@ -49,7 +49,7 @@ namespace LightNap.Core.Extensions
         /// <returns>An AdminUserDto object representing the ApplicationUser object.</returns>
         public static AdminUserDto ToAdminUserDto(this ApplicationUser user)
         {
-            long? lockoutEnd = (user.LockoutEnd.GetValueOrDefault(DateTimeOffset.MinValue) < DateTime.UtcNow) ? null : user.LockoutEnd?.ToUnixTimeMilliseconds();
+            long? lockoutEnd = (user.LockoutEnd.GetValueOrDefault(DateTimeOffset.MinValue) < DateTimeOffset.UtcNow) ? null : user.LockoutEnd?.ToUnixTimeMilliseconds();
 
             return new AdminUserDto()
             {

--- a/src/LightNap.Core/Extensions/ApplicationUserExtensions.cs
+++ b/src/LightNap.Core/Extensions/ApplicationUserExtensions.cs
@@ -49,7 +49,7 @@ namespace LightNap.Core.Extensions
         /// <returns>An AdminUserDto object representing the ApplicationUser object.</returns>
         public static AdminUserDto ToAdminUserDto(this ApplicationUser user)
         {
-            long? lockoutEnd = (user.LockoutEnd.GetValueOrDefault(DateTime.MinValue) < DateTime.UtcNow) ? null : user.LockoutEnd?.ToUnixTimeMilliseconds();
+            long? lockoutEnd = (user.LockoutEnd.GetValueOrDefault(DateTimeOffset.MinValue) < DateTime.UtcNow) ? null : user.LockoutEnd?.ToUnixTimeMilliseconds();
 
             return new AdminUserDto()
             {


### PR DESCRIPTION
Had issues with the implicit conversion DateTime -> DateTimeOffset.

```
The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')
```