### PR TITLE
Remove unnecessary csproj additions from scaffolder

### DIFF
--- a/src/Scaffolding/LightNap.Scaffolding/ProjectManager/IProjectManager.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/ProjectManager/IProjectManager.cs
@@ -11,12 +11,5 @@
         /// <param name="projectPath">The path to the project to build.</param>
         /// <returns>A <see cref="ProjectBuildResult"/> containing the result of the build operation.</returns>
         ProjectBuildResult BuildProject(string projectPath);
-
-        /// <summary>
-        /// Adds a file to the project at the specified path.
-        /// </summary>
-        /// <param name="projectPath">The path to the project.</param>
-        /// <param name="filePath">The path to the file to add.</param>
-        void AddFileToProject(string projectPath, string filePath);
     }
 }

--- a/src/Scaffolding/LightNap.Scaffolding/ProjectManager/ProjectManager.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/ProjectManager/ProjectManager.cs
@@ -57,21 +57,5 @@ namespace LightNap.Scaffolding.ProjectManager
                 Success = true
             };
         }
-
-        /// <summary>
-        /// Adds a file to the project at the specified path.
-        /// </summary>
-        /// <param name="projectPath">The path to the project file.</param>
-        /// <param name="filePath">The path to the file to add.</param>
-        public void AddFileToProject(string projectPath, string filePath)
-        {
-            var projectCollection = new ProjectCollection();
-            var project = projectCollection.LoadProject(projectPath);
-
-            var relativeFilePath = Path.GetRelativePath(Path.GetDirectoryName(projectPath)!, filePath);
-            project.AddItem("Compile", relativeFilePath);
-
-            project.Save();
-        }
     }
 }

--- a/src/Scaffolding/LightNap.Scaffolding/ServiceRunner/ServiceRunner.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/ServiceRunner/ServiceRunner.cs
@@ -47,6 +47,15 @@ namespace LightNap.Scaffolding.ServiceRunner
 
             var templateItems = new List<TemplateItem>
                 {
+                    new(Path.Combine(executingPath, "Templates/Server/CreateDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Create{type.Name}Dto.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/Dto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Response/{type.Name}Dto.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/Extensions.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Extensions/{type.Name}Extensions.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/Interface.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Interfaces/I{type.Name}Service.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/SearchDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Search{type.Name}Dto.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/Service.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Services/{type.Name}Service.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/UpdateDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Update{type.Name}Dto.cs"),
+                    new(Path.Combine(executingPath, "Templates/Server/Controller.cs.txt"), $"{parameters.WebApiProjectPath}/Controllers/{pascalNamePlural}Controller.cs"),
+
                     new(Path.Combine(executingPath, "Templates/Client/routes.ts.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/routes.ts"),
                     new(Path.Combine(executingPath, "Templates/Client/index.component.html.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/index/index.component.html"),
                     new(Path.Combine(executingPath, "Templates/Client/index.component.ts.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/index/index.component.ts"),

--- a/src/Scaffolding/LightNap.Scaffolding/ServiceRunner/ServiceRunner.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/ServiceRunner/ServiceRunner.cs
@@ -47,15 +47,6 @@ namespace LightNap.Scaffolding.ServiceRunner
 
             var templateItems = new List<TemplateItem>
                 {
-                    new(Path.Combine(executingPath, "Templates/Server/CreateDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Create{type.Name}Dto.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/Dto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Response/{type.Name}Dto.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/Extensions.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Extensions/{type.Name}Extensions.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/Interface.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Interfaces/I{type.Name}Service.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/SearchDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Search{type.Name}Dto.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/Service.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Services/{type.Name}Service.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/UpdateDto.cs.txt"), $"{parameters.CoreProjectPath}/{pascalNamePlural}/Dto/Request/Update{type.Name}Dto.cs", parameters.CoreProjectFilePath),
-                    new(Path.Combine(executingPath, "Templates/Server/Controller.cs.txt"), $"{parameters.WebApiProjectPath}/Controllers/{pascalNamePlural}Controller.cs", parameters.WebApiProjectFilePath),
-
                     new(Path.Combine(executingPath, "Templates/Client/routes.ts.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/routes.ts"),
                     new(Path.Combine(executingPath, "Templates/Client/index.component.html.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/index/index.component.html"),
                     new(Path.Combine(executingPath, "Templates/Client/index.component.ts.txt"), $"{parameters.ClientAppPath}/{kebabNamePlural}/components/pages/index/index.component.ts"),
@@ -85,11 +76,6 @@ namespace LightNap.Scaffolding.ServiceRunner
             foreach (var template in templateItems)
             {
                 templateManager.ProcessTemplate(template, templateParameters);
-
-                if (template.AddToProjectPath != null)
-                {
-                    projectManager.AddFileToProject(template.AddToProjectPath, template.OutputFile);
-                }
 
                 Console.WriteLine($"Generated {template.OutputFile}");
             }

--- a/src/Scaffolding/LightNap.Scaffolding/TemplateManager/TemplateItem.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/TemplateManager/TemplateItem.cs
@@ -6,7 +6,7 @@ namespace LightNap.Scaffolding.TemplateManager
     /// Represents a template item with a template file, output file, and an optional project path.
     /// </summary>
     [method: SetsRequiredMembers]
-    public class TemplateItem(string templateFile, string outputFile, string? addToProjectPath = null)
+    public class TemplateItem(string templateFile, string outputFile)
     {
         /// <summary>
         /// Gets or sets the template file path.

--- a/src/Scaffolding/LightNap.Scaffolding/TemplateManager/TemplateItem.cs
+++ b/src/Scaffolding/LightNap.Scaffolding/TemplateManager/TemplateItem.cs
@@ -18,9 +18,5 @@ namespace LightNap.Scaffolding.TemplateManager
         /// </summary>
         public required string OutputFile { get; set; } = outputFile;
 
-        /// <summary>
-        /// Gets or sets the optional project path to add the output file to.
-        /// </summary>
-        public string? AddToProjectPath { get; set; } = addToProjectPath;
     }
 }


### PR DESCRIPTION
Removed the addition by the scaffolder of an ItemGroup containing filenames in Core and WebApi .csproj files.

Modern .csproj files automatically pick up all .cs files, so the addition of these files lead to duplication errors, thus they have been removed.

This removal negated the need for the AddFileToProject method in ProjectManager.cs, so the method was also removed.