### PR TITLE
Unbreak frontend test:ci after orval regen

### DIFF
--- a/src/lightnap-ng/src/app/core/features/users/services/admin-users.service.spec.ts
+++ b/src/lightnap-ng/src/app/core/features/users/services/admin-users.service.spec.ts
@@ -53,15 +53,14 @@ describe("AdminUsersService", () => {
     it("should map role names to role objects correctly", async () => {
       const userId = "user-id";
 
-      // Generate realistic role data
-      const allRoles = getGetRolesResponseMock() || [];
-
-      // Pick specific role names from the generated roles to ensure they exist
+      // Use explicit role data rather than the faker-driven mock, which returns a random
+      // count (min:1, max:10) and produces flaky failures when the count is < 2.
+      const allRoles: RoleDto[] = [
+        { name: "Administrator", displayName: "Administrator", description: "Admin role" },
+        { name: "ContentEditor", displayName: "Content Editor", description: "Content editor role" },
+        { name: "Member", displayName: "Member", description: "Member role" },
+      ];
       const userRoleNames = allRoles.slice(0, 2).map(role => role.name || "");
-
-      if (userRoleNames.length < 2) {
-        throw new Error("Not enough roles generated for testing.");
-      }
 
       webApiServiceSpy.getRoles.mockReturnValue(of(allRoles) as any);
       webApiServiceSpy.getRolesForUser.mockReturnValue(of(userRoleNames) as any);

--- a/src/lightnap-ng/src/app/pages/identity/external-logins/register/register.component.ts
+++ b/src/lightnap-ng/src/app/pages/identity/external-logins/register/register.component.ts
@@ -68,6 +68,7 @@ export class RegisterComponent implements OnInit {
         deviceDetails: navigator.userAgent,
         rememberMe: this.form.value.rememberMe!,
         userName: this.form.value.userName!,
+        marketingOptIn: false,
       })
       .pipe(finalize(() => this.#blockUi.hide()))
       .subscribe({

--- a/src/lightnap-ng/src/app/pages/identity/register/register.component.spec.ts
+++ b/src/lightnap-ng/src/app/pages/identity/register/register.component.spec.ts
@@ -176,6 +176,7 @@ describe("RegisterComponent", () => {
       userName: "testuser",
       rememberMe: false,
       deviceDetails: expect.any(String),
+      marketingOptIn: false,
     });
   });
 

--- a/src/lightnap-ng/src/app/pages/identity/register/register.component.ts
+++ b/src/lightnap-ng/src/app/pages/identity/register/register.component.ts
@@ -59,6 +59,7 @@ export class RegisterComponent {
         deviceDetails: navigator.userAgent,
         rememberMe: this.form.value.rememberMe!,
         userName: this.form.value.userName!,
+        marketingOptIn: false,
       })
       .pipe(finalize(() => this.#blockUi.hide()))
       .subscribe({


### PR DESCRIPTION
## Summary
The orval regen that landed with PR #75 brought the generated TypeScript client into sync with the backend's actual surface, including the existing-on-main `MarketingOptIn` field on `RegisterRequestDto` and `ExternalLoginRegisterRequestDto` (added by migration `20260523011719_AddUserMarketingOptIn`). The two register call sites in the SPA were not passing the field — `npm run test:ci` started failing on a TS compile error. This PR sends `marketingOptIn: false` from both call sites and updates the matching spec assertion.

A separate flaky test in `admin-users.service.spec.ts` is also fixed: it depended on `getGetRolesResponseMock()` returning ≥ 2 items, but that mock uses `faker.number.int({ min: 1, max: 10 })`, so a faker draw of `1` produced an unrelated "Not enough roles generated for testing" failure. Replaced with explicit fixture data.

## Changes
- `src/app/pages/identity/register/register.component.ts` — `register()` call now includes `marketingOptIn: false`.
- `src/app/pages/identity/external-logins/register/register.component.ts` — same for `completeExternalLoginRegistration`.
- `src/app/pages/identity/register/register.component.spec.ts` — assertion updated to match the new call shape.
- `src/app/core/features/users/services/admin-users.service.spec.ts` — `getUserRoles` test uses explicit `RoleDto[]` fixtures rather than the faker-driven mock.

## Tests
- `npm run test:ci` — 668/668 passing across 55 files.

## Migration / breaking-change notes
None. The backend has been silently defaulting `MarketingOptIn` to `false` since the migration shipped (no `[Required]` annotation in C#), so sending `marketingOptIn: false` preserves prior runtime behavior. A real opt-in checkbox in the UI is a separate UX concern and not in this PR's scope.

## Configuration
None.